### PR TITLE
API endpoint has been discontinued see sslmate.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ nmap --script hostmap-crtsh.nse target.com
 ```
 **from CertSpotter**
 ```
-curl -s "https://certspotter.com/api/v1/issuances?domain=target.com&include_subdomains=true&expand=dns_names" | jq .[].dns_names | grep -Po "(([\w.-]*)\.([\w]*)\.([A-z]))\w+" | sort -u
+curl -s "https://api.certspotter.com/v1/issuances?domain=target.com&include_subdomains=true&expand=dns_names" | jq .[].dns_names | grep -Po "(([\w.-]*)\.([\w]*)\.([A-z]))\w+" | sort -u
 ```
 **from Archive**
 ```


### PR DESCRIPTION
When using the original endpoint you get this error: "This API endpoint has been discontinued. Please see https://sslmate.com/help/reference/ct_search_api_v1 for documentation about the replacement API endpoint."


The new endpoint is https://api.certspotter.com/v1/issuances?domain=DOMAIN 